### PR TITLE
feat: support custom branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ Use the following instructions to setup this software on a linux server:
 Instructions on setting up lxconsole as a docker image.
 1. Build the docker image (sudo docker build --no-cache -t penninglabs/lxconsole:v0.0.0 .)
 2. Run the docker container (sudo docker run -p 5000:5000 --name lxconsole -d penninglabs/lxconsole:v0.0.0)
-3. Additionally the flask session secret key can be set using the environment variable LXCONSOLE_SECRET_KEY. 
-4. Mounted volumes of interest for persistence include the certs (lxconsole client.key and client.crt) and instance (db.sqlite3 database) directories:
+3. Additionally the flask session secret key can be set using the environment variable LXCONSOLE_SECRET_KEY.
+4. Branding can be customized through environment variables:
+   - `LXCONSOLE_BRAND_NAME` sets the displayed application name.
+   - `LXCONSOLE_LOGO_LIGHT`, `LXCONSOLE_LOGO_DARK` and `LXCONSOLE_LOGO_BG` define paths (relative to `static/`) for the light, dark and background logos.
+   - `LXCONSOLE_PRIMARY_COLOR` overrides the primary UI color (hex value).
+5. Mounted volumes of interest for persistence include the certs (lxconsole client.key and client.crt) and instance (db.sqlite3 database) directories:
   - /opt/lxconsole/certs
   - /opt/lxconsole/instance
 

--- a/lxconsole/__init__.py
+++ b/lxconsole/__init__.py
@@ -25,6 +25,25 @@ login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 login_manager.login_message_category = 'info'
 
+# Branding / theming configuration with environment variable overrides
+app.config['BRAND_NAME'] = os.environ.get('LXCONSOLE_BRAND_NAME', 'lxconsole')
+app.config['LOGO_LIGHT'] = os.environ.get('LXCONSOLE_LOGO_LIGHT', 'assets/img/logo-light.svg')
+app.config['LOGO_DARK'] = os.environ.get('LXCONSOLE_LOGO_DARK', 'assets/img/logo-dark.svg')
+app.config['LOGO_BG'] = os.environ.get('LXCONSOLE_LOGO_BG', 'assets/img/logo-bg.svg')
+app.config['PRIMARY_COLOR'] = os.environ.get('LXCONSOLE_PRIMARY_COLOR', '#007bff')
+
+
+@app.context_processor
+def inject_branding():
+    """Expose branding variables to all templates."""
+    return {
+        'brand_name': app.config['BRAND_NAME'],
+        'logo_light': app.config['LOGO_LIGHT'],
+        'logo_dark': app.config['LOGO_DARK'],
+        'logo_bg': app.config['LOGO_BG'],
+        'primary_color': app.config['PRIMARY_COLOR'],
+    }
+
 #Put below app declaration to prevent circular import
 from lxconsole import routes
 

--- a/lxconsole/static/css/styles.css
+++ b/lxconsole/static/css/styles.css
@@ -1,3 +1,31 @@
+:root {
+  --primary: #007bff;
+}
+
+.btn-primary {
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active {
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
+.bg-primary {
+  background-color: var(--primary) !important;
+}
+
+.text-primary {
+  color: var(--primary) !important;
+}
+
+.border-primary {
+  border-color: var(--primary) !important;
+}
+
 .small-box .icon > i.fa, .small-box .icon > i.fab, .small-box .icon > i.fad, .small-box .icon > i.fal, .small-box .icon > i.far, .small-box .icon > i.fas, .small-box .icon > i.ion {
   font-size: 50px;
   top: 20px;
@@ -59,13 +87,13 @@ code {
 
 td.details-control {
   text-align:center;
-  color:#007bff ;
-cursor: pointer;
+  color:var(--primary);
+  cursor: pointer;
 }
 
 tr.shown td.details-control {
-text-align:center; 
-color:#ff0000 ;
+  text-align:center;
+  color:#ff0000 ;
 }
 
 .table-hover tbody tr:hover td, .table-hover tbody tr:hover th {
@@ -85,8 +113,8 @@ color:#ff0000 ;
   font-weight: 500;
   margin-right: 3.75px;
   margin-bottom: 3.75px;
-  background-color: #007bff;
-  border: 1px solid #007bff;
+  background-color: var(--primary);
+  border: 1px solid var(--primary);
   color: #fff;
   word-break: break-all;
   box-sizing: border-box;

--- a/lxconsole/templates/head.html
+++ b/lxconsole/templates/head.html
@@ -1,8 +1,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/png" href="{{ url_for('static', filename='assets/img/logo-light.svg') }}">
-  <title>lxconsole</title>
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename=logo_light) }}">
+  <title>{{ brand_name }}</title>
 
   <!-- Google Font: Source Sans Pro -->
   <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts/source_sans_pro.css') }}">
@@ -37,6 +37,13 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/adminlte.min.css') }}">
 
   <!-- LXD Dashboard style -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}"> 
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+
+  <style>
+    :root {
+      --primary: {{ primary_color }};
+      --bs-primary: {{ primary_color }};
+    }
+  </style>
 
 </head>

--- a/lxconsole/templates/login.html
+++ b/lxconsole/templates/login.html
@@ -5,8 +5,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='assets/img/logo-light.svg') }}">
-    <title>lxconsole</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename=logo_light) }}">
+    <title>{{ brand_name }}</title>
   
     <!-- Google Font: Source Sans Pro -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts/source_sans_pro.css') }}">
@@ -24,8 +24,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 
     <style>
+        :root {
+          --primary: {{ primary_color }};
+          --bs-primary: {{ primary_color }};
+        }
         body {
-          background-image: url("{{ url_for('static', filename='assets/img/logo-bg.svg') }}") !important;
+          background-image: url("{{ url_for('static', filename=logo_bg) }}") !important;
           background-position: center center !important;
           background-size: 100% auto !important;
           background-repeat: no-repeat;
@@ -54,14 +58,14 @@
               <div class="col-lg-5 d-none d-lg-block border-right">
                 <div class="pt-5">
                   <div class="text-center">
-                    <img src="{{ url_for('static', filename='assets/img/logo-light.svg') }}" width="50px" style="vertical-align: bottom !important;">
-                    <span class="h1"><strong>lxconsole</strong></span>
+                    <img src="{{ url_for('static', filename=logo_light) }}" width="50px" style="vertical-align: bottom !important;">
+                    <span class="h1"><strong>{{ brand_name }}</strong></span>
                   </div>
                 </div>
                 <div class="pt-5">
                   <div class="pl-4">
                     <p class="h5">An open source management console for Incus and LXD servers and clusters.</p>
-                    <p class="h5 pt-3">For instructions on using lxconsole, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
+                    <p class="h5 pt-3">For instructions on using {{ brand_name }}, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
                   </div>
                 </div>
               </div>

--- a/lxconsole/templates/login_otp.html
+++ b/lxconsole/templates/login_otp.html
@@ -5,8 +5,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='assets/img/logo-light.svg') }}">
-    <title>lxconsole</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename=logo_light) }}">
+    <title>{{ brand_name }}</title>
   
     <!-- Google Font: Source Sans Pro -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts/source_sans_pro.css') }}">
@@ -24,8 +24,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 
     <style>
+        :root {
+          --primary: {{ primary_color }};
+          --bs-primary: {{ primary_color }};
+        }
         body {
-          background-image: url("{{ url_for('static', filename='assets/img/logo-bg.svg') }}") !important;
+          background-image: url("{{ url_for('static', filename=logo_bg) }}") !important;
           background-position: center center !important;
           background-size: 100% auto !important;
           background-repeat: no-repeat;
@@ -54,14 +58,14 @@
               <div class="col-lg-5 d-none d-lg-block border-right">
                 <div class="pt-5">
                   <div class="text-center">
-                    <img src="{{ url_for('static', filename='assets/img/logo-light.svg') }}" width="50px" style="vertical-align: bottom !important;">
-                    <span class="h1"><strong>lxconsole</strong></span>
+                    <img src="{{ url_for('static', filename=logo_light) }}" width="50px" style="vertical-align: bottom !important;">
+                    <span class="h1"><strong>{{ brand_name }}</strong></span>
                   </div>
                 </div>
                 <div class="pt-5">
                   <div class="pl-4">
                     <p class="h5">An open source management console for Incus and LXD servers and clusters.</p>
-                    <p class="h5 pt-3">For instructions on using lxconsole, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
+                    <p class="h5 pt-3">For instructions on using {{ brand_name }}, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
                   </div>
                 </div>
               </div>

--- a/lxconsole/templates/modals/main.html
+++ b/lxconsole/templates/modals/main.html
@@ -3,7 +3,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">About lxconsole</h5>
+        <h5 class="modal-title" id="exampleModalLabel">About {{ brand_name }}</h5>
         <button class="close" type="button" data-bs-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">×</span>
         </button>
@@ -11,7 +11,7 @@
       <div class="modal-body">
         <div class="row">
           <div class="col-12">
-            <p>Lxconsole is an open source management console providing a web-based user interface capable of managing multiple LXD/Incus servers from a single location.</p>
+            <p>{{ brand_name }} is an open source management console providing a web-based user interface capable of managing multiple LXD/Incus servers from a single location.</p>
             <p>
               <strong>Version</strong>: <span id="versionNumber">0.6.2</span> <br />
               <strong>License</strong>: AGPL-3.0 <br />

--- a/lxconsole/templates/register.html
+++ b/lxconsole/templates/register.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='assets/img/logo-light.svg') }}">
-    <title>lxconsole</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename=logo_light) }}">
+    <title>{{ brand_name }}</title>
 
     <!-- Google Font: Source Sans Pro -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts/source_sans_pro.css') }}">
@@ -24,8 +24,12 @@
 
     
     <style>
+        :root {
+          --primary: {{ primary_color }};
+          --bs-primary: {{ primary_color }};
+        }
         body {
-          background-image: url("{{ url_for('static', filename='assets/img/logo-bg.svg') }}") !important;
+          background-image: url("{{ url_for('static', filename=logo_bg) }}") !important;
           background-position: center center !important;
           background-size: 100% auto !important;
           background-repeat: no-repeat;
@@ -53,15 +57,15 @@
 
                 <div class="pt-5">
                   <div class="text-center">
-                    <img src="{{ url_for('static', filename='assets/img/logo-light.svg') }}" width="50px" style="vertical-align: bottom !important;">
-                    <span class="h1"><strong>lxconsole</strong></span>
+                    <img src="{{ url_for('static', filename=logo_light) }}" width="50px" style="vertical-align: bottom !important;">
+                    <span class="h1"><strong>{{ brand_name }}</strong></span>
                   </div>
                 </div>
 
                 <div class="pt-5">
                   <div class="pl-4">
                     <p class="h5">An open source management console for Incus and LXD servers and clusters.</p>
-                    <p class="h5 pt-3">For instructions on using lxconsole, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
+                    <p class="h5 pt-3">For instructions on using {{ brand_name }}, visit <a href="https://lxconsole.com" target="_blank">https://lxconsole.com</a>.</p>
                   </div>
                 </div>
                   

--- a/lxconsole/templates/sidebar.html
+++ b/lxconsole/templates/sidebar.html
@@ -2,8 +2,8 @@
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Brand Logo -->
     <a href="/" class="brand-link">
-      <img src="{{ url_for('static', filename='assets/img/logo-dark.svg') }}" alt="Logo" class="brand-image elevation-3" style="opacity: .8">
-      <span class="brand-text"><strong>lx</strong>console</span>
+      <img src="{{ url_for('static', filename=logo_dark) }}" alt="Logo" class="brand-image elevation-3" style="opacity: .8">
+      <span class="brand-text"><strong>{{ brand_name }}</strong></span>
     </a>
 
     <!-- Sidebar -->


### PR DESCRIPTION
## Summary
- allow overriding brand name, logos and primary color via environment variables
- update templates to display configurable branding and use CSS variable for theming
- document new branding options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

